### PR TITLE
Add CLI to speech module + enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,15 @@
 
    You can repeat the points 3 and 4 for support multiple languages.
 
+   You can test if your token is working by running:
+
+   `
+   $ python src/audiotools/speech.py wit_api_key some_file.mp3 transcription.txt
+   `
+
 5. Create your own Yandex translate token on [Yandex website](https://tech.yandex.com/translate/)
 
-6. Edit the file **config/yandex.json** 
+6. Edit the file **config/yandex.json**
 
    `{
    	"translate_key": "YOUR YANDEX TOKEN"
@@ -70,7 +76,7 @@ You can install easily with Docker.
 
 2. Run the script **dockerRun.sh** to create and start the docker container.
 
-   In the run script, the docker directories **config**, **data** and **values** are binding with the repository directory. 
+   In the run script, the docker directories **config**, **data** and **values** are binding with the repository directory.
    If you want to edit the files in the configuration directories you can do this simply by stopping the container.
    As soon as you finish editing the files, just restart the container  to make them active.
 

--- a/src/audiotools/speech.py
+++ b/src/audiotools/speech.py
@@ -69,16 +69,16 @@ def __preprocess_audio(audio):
   return audio.set_sample_width(2).set_channels(1).set_frame_rate(8000)
 
 def transcribe(path, lang):
-  logging.info("Transcribing file %s", path)
+  logger.info("Transcribing file %s", path)
   audio = AudioSegment.from_file(path)
 
   chunks = __generate_chunks(__preprocess_audio(audio))
-  logging.debug("Got %d chunks", len(chunks))
+  logger.debug("Got %d chunks", len(chunks))
 
   for i, chunk in enumerate(chunks):
-    logging.debug("Transcribing chunk %d", i)
+    logger.debug("Transcribing chunk %d", i)
     r = __transcribe_chunk(chunk, lang)
-    logging.debug(r)
+    logger.debug(r)
 
     if r is not None:
       yield r

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -11,7 +11,7 @@ __configs = {}
 
 def parse_file(file):
   logger.info("Loading config file %s", file)
-  
+
   with open(file) as f:
     data = json.load(f)
   return data

--- a/src/transcriberbot/handlers_messages.py
+++ b/src/transcriberbot/handlers_messages.py
@@ -77,11 +77,11 @@ def transcribe_audio_file(bot, update, path):
 
     while retry and TranscriberBot.get().thread_running(message_id):
       try:
-        if len(text + speech) >= 4000:
+        if len(text + " " + speech) >= 4000:
           text = R.get_string_resource("transcription_continues", lang) + "\n"
           message = bot.send_message(
             chat_id=chat_id,
-            text=text + speech + " <b>[..]</b>",
+            text=text + " " + speech + " <b>[..]</b>",
             reply_to_message_id=message.message_id,
             parse_mode="html",
             is_group=is_group,
@@ -89,7 +89,7 @@ def transcribe_audio_file(bot, update, path):
           ).result()
         else:
           message = bot.edit_message_text(
-            text=text + speech + " <b>[..]</b>",
+            text=text + " " + speech + " <b>[..]</b>",
             chat_id=chat_id,
             message_id=message.message_id,
             parse_mode="html",
@@ -97,7 +97,7 @@ def transcribe_audio_file(bot, update, path):
             reply_markup=keyboard
           ).result()
 
-        text += ' ' + speech
+        text += " " + speech
         retry = False
         success = True
 

--- a/values/strings.xml
+++ b/values/strings.xml
@@ -63,11 +63,13 @@ LTC: {code}LdsVPxqHR6PuKeMNvGYmMEkBRQ7M3AP3uY{/code}
 <string name="translate_reply_to_message">You must reply to a message in order to translate it</string>
 
 <string name="privacy_policy">
-We do not store any personal data or media content (such as audio or pictures). 
-The only user data we store is the telegram chat id along with the chosen settings. 
-Voice/audio messages are sent to (wit.ai https://wit.ai/terms) for transcription, and are immediately deleted after the transcription is completed. 
-Pictures are immediately deleted from our server after OCR or QR recognition is perfomed (offline). 
+We do not store any personal data or media content (such as audio or pictures).
+The only user data we store is the telegram chat id along with the chosen settings.
+Voice/audio messages are sent to (wit.ai https://wit.ai/terms) for transcription, and are immediately deleted after the transcription is completed.
+Pictures are immediately deleted from our server after OCR or QR recognition is perfomed (offline).
 We do NOT store ANY message content (text, multimedia or anything else).
 </string>
+
+<string name="unknown_api_key">{b}ERROR:{/b} oops, cannot find Wit API key for language {language}. :(</string>
 
 </resources>

--- a/values/strings_es-ES.xml
+++ b/values/strings_es-ES.xml
@@ -70,4 +70,7 @@ Los mensajes de audio se envían a (wit.ai https://wit.ai/terms) para la transcr
 Las fotos se borran inmediatamente de nuestro servidor una vez se ha escandado en busca de texto o QR (offline).
 NO guardamos el contenido de NINGÚN mensaje (textp, multimedia o cualquier otra cosa)
 </string>
+
+<string name="unknown_api_key">{b}ERROR:{/b} oops, no encontré la llave API Wit para la lengua {language}. :(</string>
+
 </resources>

--- a/values/strings_it-IT.xml
+++ b/values/strings_it-IT.xml
@@ -10,7 +10,7 @@ Aggiungimi ad un gruppo o inoltrami i messaggi vocali ricevuti.
 Scegli una lingua (per i messaggi vocali):
 {languages}
 
-Per qualsiasi problema, o per metterti in contatto con gli sviluppatori, usa @transcribersupport_bot. 
+Per qualsiasi problema, o per metterti in contatto con gli sviluppatori, usa @transcribersupport_bot.
 Puoi effettuare una donazione con il comando /donate, ci aiuterà a sostenere i costi del servizio e a migliorarlo.
 
 {b}Nota{/b}: nei gruppi, il bot risponderà solo ai comandi dati {b}dagli admin{/b}
@@ -71,4 +71,7 @@ Le immagini vengono rimosse dai nostri server dopo che l'OCR o il rilevamento di
 
 NON memorizziamo nessun CONTENUTO dei messaggi (testo, multimedia o altro).
 </string>
+
+<string name="unknown_api_key">{b}ERRORE:{/b} ops, non ho trovato la chiave API Wit per la lingua {language}. :(</string>
+
 </resources>

--- a/values/strings_pt-BR.xml
+++ b/values/strings_pt-BR.xml
@@ -71,4 +71,6 @@ Imagens são imediatamente apagadas do nosso servidor após o reconhecimento de 
 Nós NÃO armazenamos NENHUM conteúdo de mensagens (texto, multimídia ou qualquer outra coisa).
 </string>
 
+<string name="unknown_api_key">{b}ERRO:{/b} ops, não encontrei a chave de API Wit para a língua {language}. :(</string>
+
 </resources>


### PR DESCRIPTION
Hi, thanks for your project. I've created a new branch with the following enhancements:

- Use the correct logger object in `audiotools/speech.py`
- Move config-related code (get Wit API key) from `audiotools/speech.py` to `transcriberbot/handlers_messages.py` (needed to add a new bot message in case the API is missing, so the user receive an error feedback instead of empty message)
- Add a command-line interface to `audiotools/speech.py`, making it easy to run the transcribing code without setting up the whole Telegram bot
- Add a space between speeches while iterating over chunks

> Note: because of time constraints, I couldn't test the changes in the file `transcriberbot/handlers_messages.py` (all the other files were tested and the CLI works perfectly).