### PR TITLE
Feature/transcribe video files

### DIFF
--- a/config/app.json
+++ b/config/app.json
@@ -30,6 +30,7 @@
   },
   "voice_max_threads": 30,
   "photos_max_threads": 10,
+  "max_media_voice_file_size": 20971520,
 
   "audio_ext": [
     "3gpp",

--- a/config/app.json
+++ b/config/app.json
@@ -32,11 +32,20 @@
   "photos_max_threads": 10,
 
   "audio_ext": [
-    "wav", 
-    "opus", 
-    "3gpp", 
-    "m4a", 
-    "ogg"
+    "3gpp",
+    "m4a",
+    "ogg",
+    "ogx",
+    "opus",
+    "wav"
+  ],
+
+  "video_ext": [
+    "avi",
+    "mkv",
+    "mp4",
+    "ogv",
+    "webm"
   ],
 
   "antiflood": {

--- a/src/resources/loader.py
+++ b/src/resources/loader.py
@@ -32,12 +32,12 @@ def _load_xml_resouce(path):
   if lang not in strings_r:
     strings_r[lang] = {}
 
-  replacements = (('{b}', '<b>'), ('{/b}', '</b>'), 
-  ('{i}', '<i>'), ('{/i}', '</i>'), 
-  ('{code}', '<code>'), ('{/code}', '</code>'))  
-  
+  replacements = (('{b}', '<b>'), ('{/b}', '</b>'),
+  ('{i}', '<i>'), ('{/i}', '</i>'),
+  ('{code}', '<code>'), ('{/code}', '</code>'))
+
   for string in e.findall('string'):
-    if string.text is None: 
+    if string.text is None:
       continue
 
     value = functools.reduce(lambda s, kv: s.replace(*kv), replacements, string.text)
@@ -73,4 +73,3 @@ def get_string_resource(id, lang=None):
     rr = strings_r['default'][id]
 
   return rr
-

--- a/src/transcriberbot/handlers_messages.py
+++ b/src/transcriberbot/handlers_messages.py
@@ -238,11 +238,9 @@ def document(bot, update):
     logger.info('extension %s not recognized', file_ext)
     return
 
-  if voice_enabled == 0:
+  elif voice_enabled in (0, 2):
     return
 
-  if voice_enabled == 2:
-    pass
   else:
     TranscriberBot.get().voice_thread_pool.submit(
       process_media_voice, bot, update, m.document, 'audio_document'

--- a/src/transcriberbot/handlers_messages.py
+++ b/src/transcriberbot/handlers_messages.py
@@ -163,12 +163,14 @@ def transcribe_audio_file(bot, update, path):
 def process_media_voice(bot, update, media, name):
   chat_id = get_chat_id(update)
   file_size = media.file_size
+  max_size = config.get_config_prop("app").get("max_media_voice_file_size", 20 * 1024 * 1024)
 
-  if file_size >= 20*(1024**2):
+  if file_size > max_size:
     message_id = get_message_id(update)
+    error_message = R.get_string_resource("file_too_big", TBDB.get_chat_lang(chat_id)).format(max_size / (1024 * 1024)) + "\n"
     bot.send_message(
       chat_id=chat_id,
-      text=R.get_string_resource("file_too_big", TBDB.get_chat_lang(chat_id)) + "\n",
+      text=error_message,
       reply_to_message_id=message_id,
       parse_mode="html",
       is_group=chat_id < 0

--- a/src/transcriberbot/handlers_messages.py
+++ b/src/transcriberbot/handlers_messages.py
@@ -81,7 +81,7 @@ def transcribe_audio_file(bot, update, path):
           text = R.get_string_resource("transcription_continues", lang) + "\n"
           message = bot.send_message(
             chat_id=chat_id,
-            text=text + " " + speech + " <b>[..]</b>",
+            text=text + " " + speech + " <b>[...]</b>",
             reply_to_message_id=message.message_id,
             parse_mode="html",
             is_group=is_group,
@@ -89,7 +89,7 @@ def transcribe_audio_file(bot, update, path):
           ).result()
         else:
           message = bot.edit_message_text(
-            text=text + " " + speech + " <b>[..]</b>",
+            text=text + " " + speech + " <b>[...]</b>",
             chat_id=chat_id,
             message_id=message.message_id,
             parse_mode="html",

--- a/src/transcriberbot/handlers_messages.py
+++ b/src/transcriberbot/handlers_messages.py
@@ -230,8 +230,11 @@ def document(bot, update):
   m = update.message or update.channel_post
   file_name = m.document.file_name
   _, file_ext = os.path.splitext(file_name)
+  file_extension = file_ext[1:]
+  supported_audio_extensions = config.get_config_prop("app").get("audio_ext", [])
+  supported_video_extensions = config.get_config_prop("app").get("video_ext", [])
 
-  if file_ext[1:] not in config.get_config_prop("app")["audio_ext"]:
+  if file_extension not in supported_audio_extensions + supported_video_extensions:
     logger.info('extension %s not recognized', file_ext)
     return
 

--- a/values/strings.xml
+++ b/values/strings.xml
@@ -42,7 +42,7 @@ LTC: {code}LdsVPxqHR6PuKeMNvGYmMEkBRQ7M3AP3uY{/code}
 <string name="qr_enabled">QR enabled</string>
 <string name="qr_disabled">QR disabled</string>
 
-<string name="file_too_big">Sorry, file is too big! (20MB limit)</string>
+<string name="file_too_big">Sorry, file is too big! (limit: {0}MB)</string>
 
 <string name="transcribing">Transcribing...</string>
 <string name="audio_long">Audio is very long ({0}s), this will take some time</string>

--- a/values/strings.xml
+++ b/values/strings.xml
@@ -44,14 +44,14 @@ LTC: {code}LdsVPxqHR6PuKeMNvGYmMEkBRQ7M3AP3uY{/code}
 
 <string name="file_too_big">Sorry, file is too big! (20MB limit)</string>
 
-<string name="transcribing">Transcribing..</string>
+<string name="transcribing">Transcribing...</string>
 <string name="audio_long">Audio is very long ({0}s), this will take some time</string>
 <string name="transcription_text">{b}Text:{/b}</string>
 <string name="transcription_continues">{b}[continues]:{/b}</string>
 <string name="transcription_failed">Could not transcribe audio</string>
 <string name="transcription_stopped">{b}[Stopped]{/b}</string>
 
-<string name="photo_recognizing">Recognizing..</string>
+<string name="photo_recognizing">Recognizing...</string>
 <string name="ocr_result">{b}Recognized Text:{/b}</string>
 <string name="photo_no_text">No text recognized</string>
 <string name="qr_result">{b}QR Code found:{/b}</string>

--- a/values/strings_es-ES.xml
+++ b/values/strings_es-ES.xml
@@ -43,7 +43,7 @@ Mandame un mensaje de voz o una imagen con texto.
 <string name="qr_enabled">QR activado</string>
 <string name="qr_disabled">QR desactivado</string>
 
-<string name="file_too_big">¡Lo siento, el archivo es demasiado grande! (20MB max)</string>
+<string name="file_too_big">¡Lo siento, el archivo es demasiado grande! ({0}MB max)</string>
 
 <string name="transcribing">Transcribiendo...</string>
 <string name="audio_long">El audio es muy largo ({0}s), esto llevará un tiempo...</string>

--- a/values/strings_it-IT.xml
+++ b/values/strings_it-IT.xml
@@ -45,14 +45,14 @@ Mandami un messaggio vocale o un'immagine con del testo
 
 <string name="file_too_big">Spiacente, il file è troppo grande! (20MB max)</string>
 
-<string name="transcribing">Trascrizione..</string>
+<string name="transcribing">Trascrizione...</string>
 <string name="audio_long">L'audio è molto lungo ({0}s), ci vorrà un po'</string>
 <string name="transcription_text">{b}Testo:{/b}</string>
 <string name="transcription_continues">{b}[continua]:{/b}</string>
 <string name="transcription_failed">Non sono riuscito a trascrivere l'audio</string>
 <string name="transcription_stopped">{b}[Fermato]{/b}</string>
 
-<string name="photo_recognizing">Riconoscimento..</string>
+<string name="photo_recognizing">Riconoscimento...</string>
 <string name="ocr_result">{b}Testo riconosciuto:{/b}</string>
 <string name="photo_no_text">Nessun testo riconosciuto</string>
 <string name="qr_result">{b}Codice QR rilevato:{/b}</string>

--- a/values/strings_it-IT.xml
+++ b/values/strings_it-IT.xml
@@ -43,7 +43,7 @@ Mandami un messaggio vocale o un'immagine con del testo
 <string name="qr_enabled">QR abilitato</string>
 <string name="qr_disabled">QR disabilitato</string>
 
-<string name="file_too_big">Spiacente, il file è troppo grande! (20MB max)</string>
+<string name="file_too_big">Spiacente, il file è troppo grande! ({0}MB max)</string>
 
 <string name="transcribing">Trascrizione...</string>
 <string name="audio_long">L'audio è molto lungo ({0}s), ci vorrà un po'</string>

--- a/values/strings_pt-BR.xml
+++ b/values/strings_pt-BR.xml
@@ -42,7 +42,7 @@ LTC: {code}LdsVPxqHR6PuKeMNvGYmMEkBRQ7M3AP3uY{/code}
 <string name="qr_enabled">QR ativado</string>
 <string name="qr_disabled">QR desativado</string>
 
-<string name="file_too_big">Desculpe, arquivo muito grande! (limite de 20MB)</string>
+<string name="file_too_big">Desculpe, arquivo muito grande! (limite de {0}MB)</string>
 
 <string name="transcribing">Transcrevendo...</string>
 <string name="audio_long">Áudio muito longo ({0}s), isso demorará um pouco</string>

--- a/values/strings_pt-BR.xml
+++ b/values/strings_pt-BR.xml
@@ -44,14 +44,14 @@ LTC: {code}LdsVPxqHR6PuKeMNvGYmMEkBRQ7M3AP3uY{/code}
 
 <string name="file_too_big">Desculpe, arquivo muito grande! (limite de 20MB)</string>
 
-<string name="transcribing">Transcrevendo..</string>
+<string name="transcribing">Transcrevendo...</string>
 <string name="audio_long">Áudio muito longo ({0}s), isso demorará um pouco</string>
 <string name="transcription_text">{b}Texto:{/b}</string>
 <string name="transcription_continues">{b}[continua]:{/b}</string>
 <string name="transcription_failed">Não pude transcrever o áudio</string>
 <string name="transcription_stopped">{b}[Parado]{/b}</string>
 
-<string name="photo_recognizing">Reconhecendo..</string>
+<string name="photo_recognizing">Reconhecendo...</string>
 <string name="ocr_result">{b}Texto reconhecido:{/b}</string>
 <string name="photo_no_text">Texto não reconhecido</string>
 <string name="qr_result">{b}Código QR encontrado:{/b}</string>


### PR DESCRIPTION
Hi! I found out the `audiotools/speech.py` script (used via CLI) can transcribe many more audio formats and video files too. So I was wondering: why not support these formats on TranscriberBot? It could be very useful in many cases, like:

- When one forwards audio from WhatsApp to Telegram directly to TranscriberBot, the file format could be in `.ogx` or `.ogg` extension. The bot currently ignores `.ogx` files;
- Creating subtitles for videos would be easier if we can just send the video file to the bot instead of first converting them to audio (this is specially useful if we're with our cellphone and unable to convert quickly). For many use cases the video quality is low and the audio quality is ok, like when recording in WhatsApp or Telegram directly (so the files aren't big).

The code already supports many more extensions then the default set, but the bot ignores it. So, why not?

To make the tests I've used [obs](https://obsproject.com/) to record a video with audio (saved as `testdata/video.mkv`). Then, I converted the video to many other video and audio formats using [ffmpeg](https://ffmpeg.org/):

```shell
ffmpeg -i testdata/video.mkv testdata/video.avi  # video to video
ffmpeg -i testdata/video.mkv testdata/video.mp3  # video to audio
ffmpeg -i testdata/video.mkv testdata/video.ogg  # video to video (!)
ffmpeg -i testdata/video.mkv testdata/video.ogv  # video to video
ffmpeg -i testdata/video.mkv testdata/video.webm # video to video
ffmpeg -i testdata/video.mp3 testdata/video-audio-only.ogg  # audio to audio (!)
```

The file sizes differ a lot, but the audio "content" is the same for all of them.

> (!) Note: Telegram uses `ogg` as audio extension, but the file format could handle video also. In the example above I've created two ogg files: one with video + audio (called `video.ogg`) and another with audio only (called `video-audio-only.ogg`). The second one was converted from the MP3 file, which is audio-only.

Then, I've set `WIT_API_KEY` environment variable and run the following commands to try to transcribe all the files:

```shell
export TIMEFORMAT="%R"
for filename in testdata/video*; do
	echo "Transcribing $filename ($(du -h $filename | cut -f 1)):"
	time python src/audiotools/speech.py $WIT_API_KEY $filename -
	echo
done
```

The result was:

```text
Transcribing testdata/video-audio-only.ogg (84K):
Olá, esse é um teste de áudio e vídeo. Vamos testar o é isso aí.
2.660

Transcribing testdata/video.avi (3.4M):
Olá, esse é um teste de áudio e vídeo. Vamos testar o é isso aí.
2.819

Transcribing testdata/video.mkv (8.3M):
Olá, esse é um teste de áudio e vídeo. Vamos testar o é isso aí.
2.729

Transcribing testdata/video.mp3 (180K):
Olá, esse é um teste de áudio e vídeo. Vamos testar o é isso aí.
2.596

Transcribing testdata/video.mp4 (1.6M):
Olá, esse é um teste de áudio e vídeo. Vamos testar o é isso aí.
3.020

Transcribing testdata/video.ogg (740K):
Olá, esse é um teste de áudio e vídeo. Vamos testar o é isso aí.
2.660

Transcribing testdata/video.ogv (740K):
Olá, esse é um teste de áudio e vídeo. Vamos testar o é isso aí.
2.861

Transcribing testdata/video.webm (1.1M):
Olá, esse é um teste de áudio e vídeo. Vamos testar o é isso aí.
2.654
```

So the CLI was able to transcribe all the files correctly (with the same results), with some time differences. The size/durations:

| Format | Contents        | Original Size  | Duration |
|--------|-----------------|----------------|----------|
| ogg    | audio only      |           84KB |   2.660s |
| avi    | audio and video |          3.4MB |   2.819s |
| mkv    | audio and video |          8.3MB |   2.596s |
| mp3    | audio only      |          180KB |   2.596s |
| mp4    | audio and video |          1.6MB |   3.020s |
| ogg    | audio and video |          740KB |   2.660s |
| ogv    | audio and video |          740KB |   2.861s |
| webm   | audio and video |          1.1MB |   2.654s |

Duration average: 2.733s, stdev: 0.151s. The duration is more or less the same even if the original file sizes differ, since `pydub` extracts the audio and convert it to raw before sending to [wit.ai](https://wit.ai/)'s API (in the cases above, the raw audio sent was ~180KB, even for the first case, where the original file is smaller than it). So the only bad thing about transcribing videos is to download (and temporarly store) a bigger file than usual, but the traffic to Wit is more or less the same as if the original file was an audio-only file.

> Note: I've added only more used formats to implement the use cases I described (like forwarding the audio/video from WhatsApp or recording directly in Telegram), but the code may support [many other video formats](https://en.wikipedia.org/wiki/Video_file_format), so feel free to add more.